### PR TITLE
Перенос параметров хилки в переменные сущности

### DIFF
--- a/addons/amxmodx/scripting/include/healthnade.inc
+++ b/addons/amxmodx/scripting/include/healthnade.inc
@@ -1,3 +1,24 @@
-// give healthnade to specified player
-// return healthnade idex or NULLENT if operation fails
-native HealthNade_GiveNade(id);
+#if defined __healthnade_included
+    #endinput
+#endif
+#define __healthnade_included
+
+#define HN_NULLENT -1
+
+// Blow radius for throwed nade
+#define var_HealthNade_Radius var_fuser1
+
+// Healing amount for throwed nade
+#define var_HealthNade_ThrowHealingAmount var_fuser2
+
+// Healing amount for drunk nade
+#define var_HealthNade_DrinkHealingAmount var_fuser3
+
+/**
+ * Give health nade with specified parameters to specified player.
+ * 
+ * @param id    Player`s index.
+ * 
+ * @return      HealthNade item index or HN_NULLENT if operation fails.
+ */
+native HealthNade_GiveNade(const id);


### PR DESCRIPTION
Позволит другим плагинам после выдачи хилки менять её параметры.
Перенесённые параметры:
- Радиус взрыва
- Кол-во восстанавливаемых ХП при взрыве гранаты
- Кол-во восстанавливаемых ХП при выпивании гранаты

Алиасы для переменных добавлены в Include-файл.

Также:
- Обновлено описание натива `HealthNade_GiveNade`
- Добавлен define для единоразового инклюда
- Путь до звука взрыва гранаты вынесен в константу
- В Include-файл добавлена константа `HN_NULLENT`, чтобы не надо было ради `NULLENT` инклюдить reapi