### PR TITLE
Update reapi_healthnade.sma

### DIFF
--- a/amxmodx/scripting/reapi_healthnade.sma
+++ b/amxmodx/scripting/reapi_healthnade.sma
@@ -622,8 +622,8 @@ explodeNade(const grenade) {
 
 		get_entvar(player, var_origin, playerOrigin);
 		if (get_distance_f(origin, playerOrigin) < fRadius) {
-			ExecuteHamB(Ham_TakeHealth, player, get_entvar(grenade, var_HealthNade_ThrowHealingAmount), DMG_GENERIC);
-			UTIL_ScreenFade(player);
+			if (ExecuteHamB(Ham_TakeHealth, player, get_entvar(grenade, var_HealthNade_ThrowHealingAmount), DMG_GENERIC))
+				UTIL_ScreenFade(player);
 		}
 	}
 


### PR DESCRIPTION
Don't blink a screen when pev->takedamage == DAMAGE_NO and pev->health >= pev->max_health