### PR TITLE
don't give bots heal nades

### DIFF
--- a/amxmodx/scripting/reapi_healthnade.sma
+++ b/amxmodx/scripting/reapi_healthnade.sma
@@ -248,7 +248,7 @@ public HookWeaponList(const msg_id, const msg_dest, const msg_entity) {
 public CBasePlayer_OnSpawnEquip_Post(const id) {
 	remove_task(id);
 
-	if (!Cvar(Give) || !UserHasFlagsS(id, Cvar(Give_AccessFlags))) {
+	if (!Cvar(Give) || is_user_bot(id) || !UserHasFlagsS(id, Cvar(Give_AccessFlags))) {
 		return;
 	}
 


### PR DESCRIPTION
If `HealthNade_Give_AccessFlags ""` to give heal nades to everyone, it includes bots.
Bots don't know how to use them and try to use them like regular grenades (zbot)
Solution is to stop giving bots heal nades on spawn.
